### PR TITLE
Restore main window geometry on launch

### DIFF
--- a/sources/mainwindow.h
+++ b/sources/mainwindow.h
@@ -10,28 +10,38 @@ class MyViewer;
 class CloudControl : public QDockWidget {
   Q_OBJECT
 public:
-  CloudControl( QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
+  CloudControl(QWidget *parent       = Q_NULLPTR,
+               Qt::WindowFlags flags = Qt::WindowFlags());
 };
 
 class SkyControl : public QDockWidget {
   Q_OBJECT
 public:
-  SkyControl( QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
+  SkyControl(QWidget *parent       = Q_NULLPTR,
+             Qt::WindowFlags flags = Qt::WindowFlags());
 };
 
 class CloudLayerViewDock : public QDockWidget {
   Q_OBJECT
 public:
-  CloudLayerViewDock(QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
+  CloudLayerViewDock(QWidget *parent       = Q_NULLPTR,
+                     Qt::WindowFlags flags = Qt::WindowFlags());
 };
 
 class MainWindow : public QMainWindow {
   Q_OBJECT
-  MyViewer* m_viewer;
+  MyViewer *m_viewer;
+  SkyControl *m_skyControl;
+  CloudLayerViewDock *m_layerView;
+
 public:
-  MainWindow(QWidget *parent = Q_NULLPTR, Qt::WindowFlags flags = Qt::WindowFlags());
+  MainWindow(QWidget *parent       = Q_NULLPTR,
+             Qt::WindowFlags flags = Qt::WindowFlags());
+
 protected:
-  void keyPressEvent(QKeyEvent*) override;
+  void keyPressEvent(QKeyEvent *) override;
+  void showEvent(QShowEvent *) override;
+  void closeEvent(QCloseEvent *) override;
 protected slots:
   void updateTitlebar();
 };

--- a/sources/mytoolbar.cpp
+++ b/sources/mytoolbar.cpp
@@ -27,6 +27,7 @@
 using namespace PathUtils;
 
 MyToolBar::MyToolBar(QWidget* parent) : QToolBar(tr("Tool bar"), parent) {
+  setObjectName("MyToolBar");  // for MainWindow::saveState()
   setFocusPolicy(Qt::NoFocus);
 
   QToolButton* menuBtn = new QToolButton(this);
@@ -38,7 +39,7 @@ MyToolBar::MyToolBar(QWidget* parent) : QToolBar(tr("Tool bar"), parent) {
 
   QToolButton* helpBtn = new QToolButton(this);
   QMenu* helpMenu      = new QMenu();
-  QAction* about       = new QAction(tr("About %1").arg(qApp->applicationName()));
+  QAction* about = new QAction(tr("About %1").arg(qApp->applicationName()));
 
   QToolButton* renderBtn   = new QToolButton(this);
   QPushButton* drawModeBtn = new QPushButton(tr("Draw"), this);
@@ -303,9 +304,9 @@ void MyToolBar::onLanguageTriggered(QAction* langAction) {
 
   // open warning popup
   if (oldLang != langAction->data().toString())
-    QMessageBox::warning(
-        this, tr("Warning"),
-        tr("Language will be changed after restarting %1.").arg(qApp->applicationName()));
+    QMessageBox::warning(this, tr("Warning"),
+                         tr("Language will be changed after restarting %1.")
+                             .arg(qApp->applicationName()));
 }
 
 void MyToolBar::onAboutTriggered() {


### PR DESCRIPTION
This PR will make KumoWorks to remember and reproduce its main window geometry.
If the geometry information is not stored in `defaultsettings.ini` (it is possible when launching for the very first time), it will open with the default geometry. I made the cloud layer window to be maximized in vertical direction in the left dock area so that the "Remove" button will be visible.

This will partially resolve #5.