### PR TITLE
fix QPainterPath include

### DIFF
--- a/sources/mygradientcontrol.cpp
+++ b/sources/mygradientcontrol.cpp
@@ -15,7 +15,7 @@
 #include <QDir>
 #include <QSettings>
 #include <QPixmap>
-#include <QPainter>
+#include <QPainterPath>
 #include <QIcon>
 #include <QComboBox>
 #include <QMessageBox>


### PR DESCRIPTION
Fix for compilation error on Linux (Fedora 33): **aggregate 'QPainterPath E0Path' has incomplete type...**

_(QPainterPath was not included)_