### PR TITLE
Dual scattering function

### DIFF
--- a/sources/cloud.cpp
+++ b/sources/cloud.cpp
@@ -146,10 +146,14 @@ float do_distance_transform(float* dst_p, QSize dim) {
 bool isInRange(int x, int min, int max) { return (x >= min) && (x < max); }
 
 Real schlickScatteringAngle(Real theta, Real k = 0.6) {
-  Real nume   = 1.0 - k * k;  // nume = 0.64
-  Real v      = 1 + k * cos(theta);
-  Real denomi = 4.0 * M_PI * v * v;
-  return nume / denomi;
+  auto func = [&](Real t) {
+    Real nume = 1.0 - k * k;  // nume = 0.64
+    Real v = 1 + k * cos(t);
+    Real denomi = 4.0 * M_PI * v * v;
+    return nume / denomi;
+  };
+  // interpolating the forward and backward scattering.
+  return 0.8 * func(theta) + 0.2 * func(theta + M_PI_2);
 }
 
 #ifdef DO_TIMER


### PR DESCRIPTION
This PR starts using the dual scattering function interpolating the forward and the backward scattering.
It will make the cloud view more distinct.

![kumo_dualfunc](https://user-images.githubusercontent.com/17974955/167559415-b75e42dd-24af-400b-a890-938818f0f6d1.png)

**Reference**
Sebastien Hillaire, [_Physically Based Sky, Atmosphere and Cloud Rendering in Frostbite_](https://media.contentapi.ea.com/content/dam/eacom/frostbite/files/s2016-pbs-frostbite-sky-clouds-new.pdf) , Page 39-40